### PR TITLE
Add csp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,7 @@ edition = "2018"
 
 [dependencies]
 http = "0.1.17"
+serde = { version = "1.0", features = ["derive"] }
+serde_json =  "1.0"
 
 [dev-dependencies]

--- a/examples/content_security_policy.rs
+++ b/examples/content_security_policy.rs
@@ -1,18 +1,18 @@
+use armor::csp;
+
 fn main() {
+    let mut policy = armor::csp::new();
+    policy
+        .default_src(csp::Source::SameOrigin)
+        .default_src("areweasyncyet.rs")
+        .script_src(csp::Source::SameOrigin)
+        .script_src(csp::Source::UnsafeInline)
+        .object_src(csp::Source::None)
+        .base_uri(csp::Source::None)
+        .upgrade_insecure_requests();
     let mut headers = http::HeaderMap::new();
     armor::armor(&mut headers);
-    let mut csp_policy = armor::ContentSecurityPolicy::new();
+    policy.apply(&mut headers);
 
-    csp_policy
-        .default_src(&["'self'", "areweasyncyet.rs"])
-        .script_src(&["'self'"])
-        .object_src(&["'none'"])
-        .upgrade_insecure_requests();
-
-    armor::content_security_policy(&mut headers, csp_policy); // "content-security-policy": "default-src 'self' areweasyncyet.rs; script-src 'self'; object-src 'none'; upgrade-insecure-requests"}
-
-    assert_eq!(headers["content-security-policy"], "default-src 'self' areweasyncyet.rs; script-src 'self'; object-src 'none'; upgrade-insecure-requests");
-
-    println!("{:?}", headers)
-    // {"x-dns-prefetch-control": "on", "x-content-type-options": "nosniff", "x-frame-options": "sameorigin", "strict-transport-security": "max-age=5184000", "x-xss-protection": "1; mode=block", "content-security-policy": "default-src 'self' areweasyncyet.rs; script-src 'self'; object-src 'none'; upgrade-insecure-requests"}
+    assert_eq!(headers["content-security-policy"], "base-uri 'none'; default-src 'self' areweasyncyet.rs; object-src 'none'; script-src 'self' 'unsafe-inline'; upgrade-insecure-requests");
 }

--- a/examples/content_security_policy.rs
+++ b/examples/content_security_policy.rs
@@ -1,0 +1,18 @@
+fn main() {
+    let mut headers = http::HeaderMap::new();
+    armor::armor(&mut headers);
+    let mut csp_policy = armor::ContentSecurityPolicy::new();
+
+    csp_policy
+        .default_src(&["'self'", "areweasyncyet.rs"])
+        .script_src(&["'self'"])
+        .object_src(&["'none'"])
+        .upgrade_insecure_requests();
+
+    armor::content_security_policy(&mut headers, csp_policy); // "content-security-policy": "default-src 'self' areweasyncyet.rs; script-src 'self'; object-src 'none'; upgrade-insecure-requests"}
+
+    assert_eq!(headers["content-security-policy"], "default-src 'self' areweasyncyet.rs; script-src 'self'; object-src 'none'; upgrade-insecure-requests");
+
+    println!("{:?}", headers)
+    // {"x-dns-prefetch-control": "on", "x-content-type-options": "nosniff", "x-frame-options": "sameorigin", "strict-transport-security": "max-age=5184000", "x-xss-protection": "1; mode=block", "content-security-policy": "default-src 'self' areweasyncyet.rs; script-src 'self'; object-src 'none'; upgrade-insecure-requests"}
+}

--- a/src/csp.rs
+++ b/src/csp.rs
@@ -9,12 +9,12 @@
 //! ```
 //! let mut policy = armor::csp::new();
 //! policy
-//! .default_src(armor::csp::Source::SameOrigin)
-//! .default_src("areweasyncyet.rs")
-//! .script_src(armor::csp::Source::SameOrigin)
-//! .object_src(armor::csp::Source::None)
-//! .base_uri(armor::csp::Source::None)
-//! .upgrade_insecure_requests();
+//!     .default_src(armor::csp::Source::SameOrigin)
+//!     .default_src("areweasyncyet.rs")
+//!     .script_src(armor::csp::Source::SameOrigin)
+//!     .object_src(armor::csp::Source::None)
+//!     .base_uri(armor::csp::Source::None)
+//!     .upgrade_insecure_requests();
 //! let mut headers = http::HeaderMap::new();
 //! armor::armor(&mut headers);
 //! policy.apply(&mut headers);

--- a/src/csp.rs
+++ b/src/csp.rs
@@ -308,7 +308,7 @@ impl ContentSecurityPolicy {
         self
     }
 
-    /// Create ad retrieve the policy value
+    /// Create and retrieve the policy value
     fn value(&mut self) -> String {
         for (directive, sources) in &self.directives {
             let policy = format!("{} {}", directive, sources.join(" "));

--- a/src/csp.rs
+++ b/src/csp.rs
@@ -1,7 +1,101 @@
-use serde::Serialize;
+//! Sets the `Content-Security-Policy` (CSP) HTTP header to prevent cross-site injections
+//!
+//! [read more](https://helmetjs.github.io/docs/csp/)
+//!
+//! [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy)
+//!
+//!
+//! ## Examples
+//! ```
+//! let mut policy = armor::csp::new();
+//! policy
+//! .default_src(armor::csp::Source::SameOrigin)
+//! .default_src("areweasyncyet.rs")
+//! .script_src(armor::csp::Source::SameOrigin)
+//! .object_src(armor::csp::Source::None)
+//! .base_uri(armor::csp::Source::None)
+//! .upgrade_insecure_requests();
+//! let mut headers = http::HeaderMap::new();
+//! armor::armor(&mut headers);
+//! policy.apply(&mut headers);
+//! assert_eq!(headers["content-security-policy"], "base-uri 'none'; default-src 'self' areweasyncyet.rs; object-src 'none'; script-src 'self'; upgrade-insecure-requests");
+//! ```
 
-// Define `report-to` directive value
-// [MDN | report-to] https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to
+use http::HeaderMap;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::fmt;
+
+/// Define source value
+/// [read more](https://content-security-policy.com)
+#[derive(Debug)]
+pub enum Source {
+    /// Set source `'self'`
+    SameOrigin,
+    /// Set source `'src'`
+    SRC,
+    /// Set source `'none'`
+    None,
+    /// Set source `'unsafe-inline'`
+    UnsafeInline,
+    /// Set source `data:`
+    Data,
+    /// Set source `mediastream:`
+    Mediastream,
+    /// Set source `https:`
+    HTTPS,
+    /// Set source `blob:`
+    Blob,
+    /// Set source `filesystem:`
+    Filesystem,
+    /// Set source `'strict-dynamic'`
+    StrictDynamic,
+    /// Set source `'unsafe-eval'`
+    UnsafeEval,
+    /// Set source `*`
+    Wildcard,
+}
+
+impl fmt::Display for Source {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Source::SameOrigin => write!(f, "'self'"),
+            Source::SRC => write!(f, "'src'"),
+            Source::None => write!(f, "'none'"),
+            Source::UnsafeInline => write!(f, "'unsafe-inline'"),
+            Source::Data => write!(f, "data:"),
+            Source::Mediastream => write!(f, "mediastream:"),
+            Source::HTTPS => write!(f, "https:"),
+            Source::Blob => write!(f, "blob:"),
+            Source::Filesystem => write!(f, "filesystem:"),
+            Source::StrictDynamic => write!(f, "'strict-dynamic'"),
+            Source::UnsafeEval => write!(f, "'unsafe-eval'"),
+            Source::Wildcard => write!(f, "*"),
+        }
+    }
+}
+
+impl AsRef<str> for Source {
+    fn as_ref(&self) -> &str {
+        match *self {
+            Source::SameOrigin => "'self'",
+            Source::SRC => "'src'",
+            Source::None => "'none'",
+            Source::UnsafeInline => "'unsafe-inline'",
+            Source::Data => "data:",
+            Source::Mediastream => "mediastream:",
+            Source::HTTPS => "https:",
+            Source::Blob => "blob:",
+            Source::Filesystem => "filesystem:",
+            Source::StrictDynamic => "'strict-dynamic'",
+            Source::UnsafeEval => "'unsafe-eval'",
+            Source::Wildcard => "*",
+        }
+    }
+}
+
+/// Define `report-to` directive value
+/// [MDN | report-to](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to)
 #[derive(Serialize, Debug)]
 pub struct ReportTo {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -12,8 +106,8 @@ pub struct ReportTo {
     include_subdomains: Option<bool>,
 }
 
-// Define `endpoints` for `report-to` directive value
-// [MDN | report-to] https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to
+/// Define `endpoints` for `report-to` directive value
+/// [MDN | report-to](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to)
 #[derive(Serialize, Debug)]
 pub struct ReportToEndpoint {
     url: String,
@@ -22,8 +116,9 @@ pub struct ReportToEndpoint {
 /// Build the Content-Security-Policy
 #[derive(Debug)]
 pub struct ContentSecurityPolicy {
-    directives: Vec<String>,
+    policy: Vec<String>,
     report_only_flag: bool,
+    directives: HashMap<String, Vec<String>>,
 }
 
 impl Default for ContentSecurityPolicy {
@@ -31,8 +126,9 @@ impl Default for ContentSecurityPolicy {
     fn default() -> Self {
         let policy = String::from("script-src 'self'; object-src 'self'");
         ContentSecurityPolicy {
-            directives: vec![policy],
+            policy: vec![policy],
             report_only_flag: false,
+            directives: HashMap::new(),
         }
     }
 }
@@ -41,16 +137,23 @@ impl ContentSecurityPolicy {
     /// Instantiates ContentSecurityPolicy
     pub fn new() -> ContentSecurityPolicy {
         ContentSecurityPolicy {
-            directives: Vec::new(),
+            policy: Vec::new(),
             report_only_flag: false,
+            directives: HashMap::new(),
         }
+    }
+
+    fn insert_directive<T: AsRef<str>>(&mut self, directive: &str, source: T) {
+        let directive = String::from(directive);
+        let directives = self.directives.entry(directive).or_insert(Vec::new());
+        let source: String = source.as_ref().to_string();
+        directives.push(source);
     }
 
     /// Defines the Content-Security-Policy `base-uri` directive
     /// [MDN | base-uri](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/base-uri)
-    pub fn base_uri(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
-        let policy = format!("base-uri {}", sources.join(" "));
-        self.directives.push(policy);
+    pub fn base_uri<T: AsRef<str>>(&mut self, source: T) -> &mut ContentSecurityPolicy {
+        self.insert_directive("base-uri", source);
         self
     }
 
@@ -58,103 +161,91 @@ impl ContentSecurityPolicy {
     /// [MDN | block-all-mixed-content](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/block-all-mixed-content)
     pub fn block_all_mixed_content(&mut self) -> &mut ContentSecurityPolicy {
         let policy = String::from("block-all-mixed-content");
-        self.directives.push(policy);
+        self.policy.push(policy);
         self
     }
 
     /// Defines the Content-Security-Policy `connect-src` directive
     /// [MDN | connect-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src)
-    pub fn connect_src(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
-        let policy = format!("connect-src {}", sources.join(" "));
-        self.directives.push(policy);
+    pub fn connect_src<T: AsRef<str>>(&mut self, source: T) -> &mut ContentSecurityPolicy {
+        self.insert_directive("connect-src", source);
         self
     }
 
     /// Defines the Content-Security-Policy `default-src` directive
     /// [MDN | default-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/default-src)
-    pub fn default_src(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
-        let policy = format!("default-src {}", sources.join(" "));
-        self.directives.push(policy);
+    pub fn default_src<T: AsRef<str>>(&mut self, source: T) -> &mut ContentSecurityPolicy {
+        self.insert_directive("default-src", source);
         self
     }
 
     /// Defines the Content-Security-Policy `font-src` directive
     /// [MDN | font-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/font-src)
-    pub fn font_src(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
-        let policy = format!("font-src {}", sources.join(" "));
-        self.directives.push(policy);
+    pub fn font_src<T: AsRef<str>>(&mut self, source: T) -> &mut ContentSecurityPolicy {
+        self.insert_directive("font-src", source);
         self
     }
 
     /// Defines the Content-Security-Policy `form-action` directive
     /// [MDN | form-action](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/form-action)
-    pub fn form_action(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
-        let policy = format!("form-action {}", sources.join(" "));
-        self.directives.push(policy);
+    pub fn form_action<T: AsRef<str>>(&mut self, source: T) -> &mut ContentSecurityPolicy {
+        self.insert_directive("form-action", source);
         self
     }
 
     /// Defines the Content-Security-Policy `frame-ancestors` directive
     /// [MDN | frame-ancestors](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors)
-    pub fn frame_ancestors(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
-        let policy = format!("frame-ancestors {}", sources.join(" "));
-        self.directives.push(policy);
+    pub fn frame_ancestors<T: AsRef<str>>(&mut self, source: T) -> &mut ContentSecurityPolicy {
+        self.insert_directive("frame-ancestors", source);
         self
     }
 
     /// Defines the Content-Security-Policy `frame-src` directive
     /// [MDN | frame-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-src)
-    pub fn frame_src(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
-        let policy = format!("frame-src {}", sources.join(" "));
-        self.directives.push(policy);
+    pub fn frame_src<T: AsRef<str>>(&mut self, source: T) -> &mut ContentSecurityPolicy {
+        self.insert_directive("frame-src", source);
         self
     }
 
     /// Defines the Content-Security-Policy `img-src` directive
     /// [MDN | img-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/img-src)
-    pub fn img_src(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
-        let policy = format!("img-src {}", sources.join(" "));
-        self.directives.push(policy);
+    pub fn img_src<T: AsRef<str>>(&mut self, source: T) -> &mut ContentSecurityPolicy {
+        self.insert_directive("img-src", source);
         self
     }
 
     /// Defines the Content-Security-Policy `media-src` directive
     /// [MDN | media-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/media-src)
-    pub fn media_src(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
-        let policy = format!("media-src {}", sources.join(" "));
-        self.directives.push(policy);
+    pub fn media_src<T: AsRef<str>>(&mut self, source: T) -> &mut ContentSecurityPolicy {
+        self.insert_directive("media-src", source);
         self
     }
 
     /// Defines the Content-Security-Policy `object-src` directive
     /// [MDN | object-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/object-src)
-    pub fn object_src(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
-        let policy = format!("object-src {}", sources.join(" "));
-        self.directives.push(policy);
+    pub fn object_src<T: AsRef<str>>(&mut self, source: T) -> &mut ContentSecurityPolicy {
+        self.insert_directive("object-src", source);
         self
     }
 
     /// Defines the Content-Security-Policy `plugin-types` directive
     /// [MDN | plugin-types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/plugin-types)
-    pub fn plugin_types(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
-        let policy = format!("plugin-types {}", sources.join(" "));
-        self.directives.push(policy);
+    pub fn plugin_types<T: AsRef<str>>(&mut self, source: T) -> &mut ContentSecurityPolicy {
+        self.insert_directive("plugin-types", source);
         self
     }
 
     /// Defines the Content-Security-Policy `require-sri-for` directive
     /// [MDN | require-sri-for](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-sri-for)
-    pub fn require_sri_for(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
-        let policy = format!("require-sri-for {}", sources.join(" "));
-        self.directives.push(policy);
+    pub fn require_sri_for<T: AsRef<str>>(&mut self, source: T) -> &mut ContentSecurityPolicy {
+        self.insert_directive("require-sri-for ", source);
         self
     }
 
     /// Defines the Content-Security-Policy `report-uri` directive
     /// [MDN | report-uri](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-uri)
-    pub fn report_uri(&mut self, uri: &str) -> &mut ContentSecurityPolicy {
-        let policy = format!("report-uri {}", uri);
-        self.directives.push(policy);
+    pub fn report_uri<T: AsRef<str>>(&mut self, uri: T) -> &mut ContentSecurityPolicy {
+        self.insert_directive("report-uri", uri);
         self
     }
 
@@ -165,7 +256,7 @@ impl ContentSecurityPolicy {
             match serde_json::to_string(&endpoint) {
                 Ok(json) => {
                     let policy = format!("report-to {}", json);
-                    self.directives.push(policy);
+                    self.policy.push(policy);
                 }
                 Err(error) => {
                     println!("{:?}", error);
@@ -177,25 +268,22 @@ impl ContentSecurityPolicy {
 
     /// Defines the Content-Security-Policy `sandbox` directive
     /// [MDN | sandbox](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/sandbox)
-    pub fn sandbox(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
-        let policy = format!("sandbox {}", sources.join(" "));
-        self.directives.push(policy);
+    pub fn sandbox<T: AsRef<str>>(&mut self, source: T) -> &mut ContentSecurityPolicy {
+        self.insert_directive("sandbox", source);
         self
     }
 
     /// Defines the Content-Security-Policy `script-src` directive
     /// [MDN | script-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src)
-    pub fn script_src(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
-        let policy = format!("script-src {}", sources.join(" "));
-        self.directives.push(policy);
+    pub fn script_src<T: AsRef<str>>(&mut self, source: T) -> &mut ContentSecurityPolicy {
+        self.insert_directive("script-src", source);
         self
     }
 
     /// Defines the Content-Security-Policy `style-src` directive
     /// [MDN | style-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src)
-    pub fn style_src(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
-        let policy = format!("style-src {}", sources.join(" "));
-        self.directives.push(policy);
+    pub fn style_src<T: AsRef<str>>(&mut self, source: T) -> &mut ContentSecurityPolicy {
+        self.insert_directive("style-src", source);
         self
     }
 
@@ -203,15 +291,14 @@ impl ContentSecurityPolicy {
     /// [MDN | upgrade-insecure-requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/upgrade-insecure-requests)
     pub fn upgrade_insecure_requests(&mut self) -> &mut ContentSecurityPolicy {
         let policy = String::from("upgrade-insecure-requests");
-        self.directives.push(policy);
+        self.policy.push(policy);
         self
     }
 
     /// Defines the Content-Security-Policy `worker-src` directive
     /// [MDN | worker-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/worker-src)
-    pub fn worker_src(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
-        let policy = format!("worker-src {}", sources.join(" "));
-        self.directives.push(policy);
+    pub fn worker_src<T: AsRef<str>>(&mut self, source: T) -> &mut ContentSecurityPolicy {
+        self.insert_directive("worker-src", source);
         self
     }
 
@@ -221,13 +308,32 @@ impl ContentSecurityPolicy {
         self
     }
 
-    /// Retrieve the `report_only_flag` flag
-    pub fn report(&self) -> bool {
-        self.report_only_flag
+    /// Create ad retrieve the policy value
+    fn value(&mut self) -> String {
+        for (directive, sources) in &self.directives {
+            let policy = format!("{} {}", directive, sources.join(" "));
+            self.policy.push(policy);
+            self.policy.sort();
+        }
+        self.policy.join("; ")
     }
 
-    /// Retrieve the policy value
-    pub fn value(&self) -> String {
-        self.directives.join("; ")
+    /// Sets the `Content-Security-Policy` (CSP) HTTP header to prevent cross-site injections
+    pub fn apply(&mut self, headers: &mut HeaderMap) {
+        let val = self.value().parse().unwrap();
+        if !self.report_only_flag {
+            headers.insert("Content-Security-Policy", val);
+        } else {
+            headers.insert("Content-Security-Policy-Report-Only", val);
+        }
+    }
+}
+
+/// Instantiates ContentSecurityPolicy
+pub fn new() -> ContentSecurityPolicy {
+    ContentSecurityPolicy {
+        policy: Vec::new(),
+        report_only_flag: false,
+        directives: HashMap::new(),
     }
 }

--- a/src/csp.rs
+++ b/src/csp.rs
@@ -145,10 +145,7 @@ impl ContentSecurityPolicy {
 
     fn insert_directive<T: AsRef<str>>(&mut self, directive: &str, source: T) {
         let directive = String::from(directive);
-        let directives = self
-            .directives
-            .entry(directive)
-            .or_insert_with(|| Vec::new());
+        let directives = self.directives.entry(directive).or_insert_with(Vec::new);
         let source: String = source.as_ref().to_string();
         directives.push(source);
     }

--- a/src/csp.rs
+++ b/src/csp.rs
@@ -1,0 +1,233 @@
+use serde::Serialize;
+
+// Define `report-to` directive value
+// [MDN | report-to] https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to
+#[derive(Serialize, Debug)]
+pub struct ReportTo {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    group: Option<String>,
+    max_age: i32,
+    endpoints: Vec<ReportToEndpoint>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    include_subdomains: Option<bool>,
+}
+
+// Define `endpoints` for `report-to` directive value
+// [MDN | report-to] https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to
+#[derive(Serialize, Debug)]
+pub struct ReportToEndpoint {
+    url: String,
+}
+
+/// Build the Content-Security-Policy
+#[derive(Debug)]
+pub struct ContentSecurityPolicy {
+    directives: Vec<String>,
+    report_only_flag: bool,
+}
+
+impl Default for ContentSecurityPolicy {
+    /// Sets the Content-Security-Policy default to "script-src 'self'; object-src 'self'"
+    fn default() -> Self {
+        let policy = String::from("script-src 'self'; object-src 'self'");
+        ContentSecurityPolicy {
+            directives: vec![policy],
+            report_only_flag: false,
+        }
+    }
+}
+
+impl ContentSecurityPolicy {
+    /// Instantiates ContentSecurityPolicy
+    pub fn new() -> ContentSecurityPolicy {
+        ContentSecurityPolicy {
+            directives: Vec::new(),
+            report_only_flag: false,
+        }
+    }
+
+    /// Defines the Content-Security-Policy `base-uri` directive
+    /// [MDN | base-uri](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/base-uri)
+    pub fn base_uri(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
+        let policy = format!("base-uri {}", sources.join(" "));
+        self.directives.push(policy);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `block-all-mixed-content` directive
+    /// [MDN | block-all-mixed-content](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/block-all-mixed-content)
+    pub fn block_all_mixed_content(&mut self) -> &mut ContentSecurityPolicy {
+        let policy = String::from("block-all-mixed-content");
+        self.directives.push(policy);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `connect-src` directive
+    /// [MDN | connect-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src)
+    pub fn connect_src(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
+        let policy = format!("connect-src {}", sources.join(" "));
+        self.directives.push(policy);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `default-src` directive
+    /// [MDN | default-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/default-src)
+    pub fn default_src(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
+        let policy = format!("default-src {}", sources.join(" "));
+        self.directives.push(policy);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `font-src` directive
+    /// [MDN | font-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/font-src)
+    pub fn font_src(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
+        let policy = format!("font-src {}", sources.join(" "));
+        self.directives.push(policy);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `form-action` directive
+    /// [MDN | form-action](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/form-action)
+    pub fn form_action(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
+        let policy = format!("form-action {}", sources.join(" "));
+        self.directives.push(policy);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `frame-ancestors` directive
+    /// [MDN | frame-ancestors](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors)
+    pub fn frame_ancestors(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
+        let policy = format!("frame-ancestors {}", sources.join(" "));
+        self.directives.push(policy);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `frame-src` directive
+    /// [MDN | frame-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-src)
+    pub fn frame_src(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
+        let policy = format!("frame-src {}", sources.join(" "));
+        self.directives.push(policy);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `img-src` directive
+    /// [MDN | img-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/img-src)
+    pub fn img_src(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
+        let policy = format!("img-src {}", sources.join(" "));
+        self.directives.push(policy);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `media-src` directive
+    /// [MDN | media-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/media-src)
+    pub fn media_src(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
+        let policy = format!("media-src {}", sources.join(" "));
+        self.directives.push(policy);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `object-src` directive
+    /// [MDN | object-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/object-src)
+    pub fn object_src(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
+        let policy = format!("object-src {}", sources.join(" "));
+        self.directives.push(policy);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `plugin-types` directive
+    /// [MDN | plugin-types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/plugin-types)
+    pub fn plugin_types(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
+        let policy = format!("plugin-types {}", sources.join(" "));
+        self.directives.push(policy);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `require-sri-for` directive
+    /// [MDN | require-sri-for](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-sri-for)
+    pub fn require_sri_for(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
+        let policy = format!("require-sri-for {}", sources.join(" "));
+        self.directives.push(policy);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `report-uri` directive
+    /// [MDN | report-uri](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-uri)
+    pub fn report_uri(&mut self, uri: &str) -> &mut ContentSecurityPolicy {
+        let policy = format!("report-uri {}", uri);
+        self.directives.push(policy);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `report-to` directive
+    /// [MDN | report-to](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to)
+    pub fn report_to(&mut self, endpoints: Vec<ReportTo>) -> &mut ContentSecurityPolicy {
+        for endpoint in endpoints.iter() {
+            match serde_json::to_string(&endpoint) {
+                Ok(json) => {
+                    let policy = format!("report-to {}", json);
+                    self.directives.push(policy);
+                }
+                Err(error) => {
+                    println!("{:?}", error);
+                }
+            }
+        }
+        self
+    }
+
+    /// Defines the Content-Security-Policy `sandbox` directive
+    /// [MDN | sandbox](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/sandbox)
+    pub fn sandbox(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
+        let policy = format!("sandbox {}", sources.join(" "));
+        self.directives.push(policy);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `script-src` directive
+    /// [MDN | script-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src)
+    pub fn script_src(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
+        let policy = format!("script-src {}", sources.join(" "));
+        self.directives.push(policy);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `style-src` directive
+    /// [MDN | style-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src)
+    pub fn style_src(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
+        let policy = format!("style-src {}", sources.join(" "));
+        self.directives.push(policy);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `upgrade-insecure-requests` directive
+    /// [MDN | upgrade-insecure-requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/upgrade-insecure-requests)
+    pub fn upgrade_insecure_requests(&mut self) -> &mut ContentSecurityPolicy {
+        let policy = String::from("upgrade-insecure-requests");
+        self.directives.push(policy);
+        self
+    }
+
+    /// Defines the Content-Security-Policy `worker-src` directive
+    /// [MDN | worker-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/worker-src)
+    pub fn worker_src(&mut self, sources: &[&str]) -> &mut ContentSecurityPolicy {
+        let policy = format!("worker-src {}", sources.join(" "));
+        self.directives.push(policy);
+        self
+    }
+
+    /// Change the header to `Content-Security-Policy-Report-Only`
+    pub fn report_only(&mut self) -> &mut ContentSecurityPolicy {
+        self.report_only_flag = true;
+        self
+    }
+
+    /// Retrieve the `report_only_flag` flag
+    pub fn report(&self) -> bool {
+        self.report_only_flag
+    }
+
+    /// Retrieve the policy value
+    pub fn value(&self) -> String {
+        self.directives.join("; ")
+    }
+}

--- a/src/csp.rs
+++ b/src/csp.rs
@@ -145,7 +145,10 @@ impl ContentSecurityPolicy {
 
     fn insert_directive<T: AsRef<str>>(&mut self, directive: &str, source: T) {
         let directive = String::from(directive);
-        let directives = self.directives.entry(directive).or_insert(Vec::new());
+        let directives = self
+            .directives
+            .entry(directive)
+            .or_insert_with(|| Vec::new());
         let source: String = source.as_ref().to_string();
         directives.push(source);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,12 +10,14 @@
 //! assert_eq!(headers["X-XSS-Protection"], "1; mode=block");
 //! ```
 
-#![forbid(unsafe_code, future_incompatible, rust_2018_idioms)]
-#![deny(missing_debug_implementations, nonstandard_style)]
+#![forbid(unsafe_code, future_incompatible)]
+#![deny(missing_debug_implementations, nonstandard_style, rust_2018_idioms)]
 #![warn(missing_docs, missing_doc_code_examples)]
 #![cfg_attr(test, deny(warnings))]
 
 use http::HeaderMap;
+mod csp;
+pub use self::csp::ContentSecurityPolicy;
 
 /// Apply all protections.
 ///
@@ -200,5 +202,35 @@ pub fn referrer_policy(headers: &mut HeaderMap, referrer: Option<ReferrerOptions
         headers.append("Referrer-Policy", policy.parse().unwrap());
     } else {
         headers.insert("Referrer-Policy", policy.parse().unwrap());
+    }
+}
+
+/// Sets the `Content-Security-Policy` header to prevent cross-site injections
+///
+/// [read more](https://helmetjs.github.io/docs/csp/)
+///
+/// [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy)
+///
+///
+/// ## Examples
+/// ```
+/// let mut headers = http::HeaderMap::new();
+/// armor::armor(&mut headers);
+/// let mut csp_policy = armor::ContentSecurityPolicy::new();
+/// csp_policy
+///     .default_src(&["'self'", "areweasyncyet.rs"])
+///     .script_src(&["'self'"])
+///     .object_src(&["'none'"])
+///     .upgrade_insecure_requests();
+/// armor::content_security_policy(&mut headers, csp_policy);
+/// assert_eq!(headers["content-security-policy"], "default-src 'self' areweasyncyet.rs; script-src 'self'; object-src 'none'; upgrade-insecure-requests");
+/// ```
+#[inline]
+pub fn content_security_policy(headers: &mut HeaderMap, csp_policy: ContentSecurityPolicy) {
+    let val = csp_policy.value().parse().unwrap();
+    if !csp_policy.report() {
+        headers.insert("Content-Security-Policy", val);
+    } else {
+        headers.insert("Content-Security-Policy-Report-Only", val);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,7 @@
 #![cfg_attr(test, deny(warnings))]
 
 use http::HeaderMap;
-mod csp;
-pub use self::csp::ContentSecurityPolicy;
+pub mod csp;
 
 /// Apply all protections.
 ///
@@ -202,35 +201,5 @@ pub fn referrer_policy(headers: &mut HeaderMap, referrer: Option<ReferrerOptions
         headers.append("Referrer-Policy", policy.parse().unwrap());
     } else {
         headers.insert("Referrer-Policy", policy.parse().unwrap());
-    }
-}
-
-/// Sets the `Content-Security-Policy` header to prevent cross-site injections
-///
-/// [read more](https://helmetjs.github.io/docs/csp/)
-///
-/// [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy)
-///
-///
-/// ## Examples
-/// ```
-/// let mut headers = http::HeaderMap::new();
-/// armor::armor(&mut headers);
-/// let mut csp_policy = armor::ContentSecurityPolicy::new();
-/// csp_policy
-///     .default_src(&["'self'", "areweasyncyet.rs"])
-///     .script_src(&["'self'"])
-///     .object_src(&["'none'"])
-///     .upgrade_insecure_requests();
-/// armor::content_security_policy(&mut headers, csp_policy);
-/// assert_eq!(headers["content-security-policy"], "default-src 'self' areweasyncyet.rs; script-src 'self'; object-src 'none'; upgrade-insecure-requests");
-/// ```
-#[inline]
-pub fn content_security_policy(headers: &mut HeaderMap, csp_policy: ContentSecurityPolicy) {
-    let val = csp_policy.value().parse().unwrap();
-    if !csp_policy.report() {
-        headers.insert("Content-Security-Policy", val);
-    } else {
-        headers.insert("Content-Security-Policy-Report-Only", val);
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -4,3 +4,21 @@ use std::error::Error;
 fn should_work() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     Ok(())
 }
+
+#[test]
+fn csp_test() {
+    let mut headers = http::HeaderMap::new();
+    armor::armor(&mut headers);
+    let mut csp_policy = armor::ContentSecurityPolicy::new();
+
+    csp_policy
+        .default_src(&["'self'", "areweasyncyet.rs"])
+        .script_src(&["'self'", "'unsafe-inline'"])
+        .object_src(&["'none'"])
+        .base_uri(&["'none'"])
+        .upgrade_insecure_requests();
+
+    armor::content_security_policy(&mut headers, csp_policy);
+
+    assert_eq!(headers["content-security-policy"], "default-src 'self' areweasyncyet.rs; script-src 'self' 'unsafe-inline'; object-src 'none'; base-uri 'none'; upgrade-insecure-requests");
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,3 +1,4 @@
+use armor::csp;
 use std::error::Error;
 
 #[test]
@@ -7,18 +8,18 @@ fn should_work() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 
 #[test]
 fn csp_test() {
+    let mut policy = armor::csp::new();
+    policy
+        .default_src(csp::Source::SameOrigin)
+        .default_src("areweasyncyet.rs")
+        .script_src(csp::Source::SameOrigin)
+        .script_src(csp::Source::UnsafeInline)
+        .object_src(csp::Source::None)
+        .base_uri(csp::Source::None)
+        .upgrade_insecure_requests();
     let mut headers = http::HeaderMap::new();
     armor::armor(&mut headers);
-    let mut csp_policy = armor::ContentSecurityPolicy::new();
+    policy.apply(&mut headers);
 
-    csp_policy
-        .default_src(&["'self'", "areweasyncyet.rs"])
-        .script_src(&["'self'", "'unsafe-inline'"])
-        .object_src(&["'none'"])
-        .base_uri(&["'none'"])
-        .upgrade_insecure_requests();
-
-    armor::content_security_policy(&mut headers, csp_policy);
-
-    assert_eq!(headers["content-security-policy"], "default-src 'self' areweasyncyet.rs; script-src 'self' 'unsafe-inline'; object-src 'none'; base-uri 'none'; upgrade-insecure-requests");
+    assert_eq!(headers["content-security-policy"], "base-uri 'none'; default-src 'self' areweasyncyet.rs; object-src 'none'; script-src 'self' 'unsafe-inline'; upgrade-insecure-requests");
 }


### PR DESCRIPTION
Add support for [Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)

## Description
Created `Content Security Policy` policy builder and implementation. 

```rust
let mut headers = http::HeaderMap::new();
armor::armor(&mut headers);
let mut csp_policy = armor::ContentSecurityPolicy::new();

csp_policy
    .default_src(&["'self'", "areweasyncyet.rs"])
    .script_src(&["'self'"])
    .object_src(&["'none'"])
    .upgrade_insecure_requests();

armor::content_security_policy(&mut headers, csp_policy);
```

## Motivation and Context
The CSP headers prevents and detects injection attacks and is included in [Helmet.js](https://helmetjs.github.io/docs/csp/) but missing from armor. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Happy [Hacktoberfest](https://hacktoberfest.digitalocean.com)!
